### PR TITLE
[BUG] Constructor with only Throwable parameter lose responseCode information

### DIFF
--- a/src/com/akamai/netstorage/NetStorageException.java
+++ b/src/com/akamai/netstorage/NetStorageException.java
@@ -28,12 +28,12 @@ public class NetStorageException extends RequestSigningException {
 	private static final long serialVersionUID = 5716437270940718895L;
 	private int responseCode = -1;
 
-	public NetStorageException(String message) {
+    public NetStorageException(String message) {
         super(message);
     }
 
     public NetStorageException(Throwable cause) {
-        super(cause);
+        this(cause.getMessage(), cause);
     }
 
 	public NetStorageException(String message, int responseCode) {


### PR DESCRIPTION
Hello,

When creating a new NetStorageException instance through the public NetStorageException(Throwable cause){...} constructor, the responseCode information is lost.
This caused a regression from our side since our code depends upon your implementation - identifying certain responseCode in some situations when uploading a file to NetStorage service.

Losing exception information when bubbling exceptions up to a handler is considered bad practice.
Please approve this minor fix to prevent this situation.

Best regards,
Ori Libhaber

Software Engineer
Harman Connected Services
