### PR TITLE
support for readTimeout and connectTimeout params

### DIFF
--- a/src/com/akamai/netstorage/NetStorage.java
+++ b/src/com/akamai/netstorage/NetStorage.java
@@ -43,8 +43,18 @@ public class NetStorage {
 
     private DefaultCredential credential;
 
+    // defaults
+    private int connectTimeout = 10000;
+    private int readTimeout = 10000;
+
     public NetStorage(DefaultCredential credential) {
         this.credential = credential;
+    }
+
+    public NetStorage(DefaultCredential credential, int connectTimeout, int readTimeout) {
+        this.credential = credential;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
     }
 
     protected URL getNetstorageUri(String path) {
@@ -64,7 +74,9 @@ public class NetStorage {
                     this.getNetstorageUri(path),
                     acsParams,
                     uploadStream,
-                    size != null && size > 0 ? size : -1
+                    size != null && size > 0 ? size : -1,
+                    this.getConnectTimeout(),
+                    this.getReadTimeout()
             ).execute(this.credential);
         }
         catch (RequestSigningException ex) {
@@ -299,5 +311,21 @@ public class NetStorage {
         }
         return true;
 	}
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
 
 }

--- a/src/com/akamai/netstorage/NetStorage.java
+++ b/src/com/akamai/netstorage/NetStorage.java
@@ -53,8 +53,8 @@ public class NetStorage {
 
     public NetStorage(DefaultCredential credential, int connectTimeout, int readTimeout) {
         this.credential = credential;
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
+        if (connectTimeout > 0) this.setConnectTimeout(connectTimeout);
+        if (readTimeout > 0) this.setReadTimeout(readTimeout);
     }
 
     protected URL getNetstorageUri(String path) {

--- a/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
+++ b/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
@@ -110,7 +110,7 @@ public class NetStorageCMSv35Signer implements RequestSigner {
      * @param params the set of bean parameters to be sent in the API request
      */
     public NetStorageCMSv35Signer(String method, URL url, APIEventBean params) {
-        this(method, url, params, null, -1L, 10000, 10000);
+        this(method, url, params, null, -1L, -1, -1);
     }
 
     /**
@@ -132,8 +132,8 @@ public class NetStorageCMSv35Signer implements RequestSigner {
         this.setUploadStream(uploadStream);
         this.setUploadSize(uploadSize);
         this.setSignVersion(SignType.HMACSHA256);
-        this.setConnectTimeout(connectTimeout);
-        this.setReadTimeout(readTimeout);
+        if (connectTimeout > 0) this.setConnectTimeout(connectTimeout);
+        if (readTimeout > 0) this.setReadTimeout(readTimeout);
     }
 
     private String method;
@@ -295,7 +295,8 @@ public class NetStorageCMSv35Signer implements RequestSigner {
         // Validate Server-Time drift
         Date currentDate = new Date();
         long responseDate = connection.getHeaderFieldDate("Date", 0);
-        if (responseDate != 0 && currentDate.getTime() - responseDate > 30 * 1000)
+        if ((responseDate != 0 && currentDate.getTime() - responseDate > 30 * 1000)
+            || (responseDate != 0 && (currentDate.getTime() - responseDate) * -1 > 30 * 1000))
             throw new NetStorageException("Local server Date is more than 30s out of sync with Remote server");
 
         // generic response

--- a/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
+++ b/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
@@ -56,6 +56,10 @@ public class NetStorageCMSv35Signer implements RequestSigner {
     private static final String AUTH_DATA_HEADER = "X-Akamai-ACS-Auth-Data";
     private static final String AUTH_SIGN_HEADER = "X-Akamai-ACS-Auth-Sign";
 
+    // defaults
+    private int connectTimeout = 10000;
+    private int readTimeout = 10000;
+
 	/**
 	 * There are multiple types of Net Storage. The following types are
 	 * detected:
@@ -106,7 +110,7 @@ public class NetStorageCMSv35Signer implements RequestSigner {
      * @param params the set of bean parameters to be sent in the API request
      */
     public NetStorageCMSv35Signer(String method, URL url, APIEventBean params) {
-        this(method, url, params, null, -1L);
+        this(method, url, params, null, -1L, 10000, 10000);
     }
 
     /**
@@ -121,13 +125,15 @@ public class NetStorageCMSv35Signer implements RequestSigner {
      * @param uploadStream the inputStream to read the bytes to upload
      * @param uploadSize   if available, the total size of the inputStream. Note, that this could be different than the Size parameter in the action line
      */
-    public NetStorageCMSv35Signer(String method, URL url, APIEventBean params, InputStream uploadStream, long uploadSize) {
+    public NetStorageCMSv35Signer(String method, URL url, APIEventBean params, InputStream uploadStream, long uploadSize, int connectTimeout, int readTimeout) {
         this.setMethod(method);
         this.setUrl(url);
         this.setParams(params);
         this.setUploadStream(uploadStream);
         this.setUploadSize(uploadSize);
         this.setSignVersion(SignType.HMACSHA256);
+        this.setConnectTimeout(connectTimeout);
+        this.setReadTimeout(readTimeout);
     }
 
     private String method;
@@ -183,6 +189,22 @@ public class NetStorageCMSv35Signer implements RequestSigner {
 
     public void setSignVersion(SignType signVersion) {
         this.signVersion = signVersion;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
     }
 
     /**
@@ -314,8 +336,8 @@ public class NetStorageCMSv35Signer implements RequestSigner {
     public InputStream execute(HttpURLConnection request, ClientCredential credential) throws RequestSigningException {
         try {
             request = sign(request, credential);
-            request.setConnectTimeout(10000);
-            request.setReadTimeout(10000);
+            request.setConnectTimeout(this.getConnectTimeout());
+            request.setReadTimeout(this.getReadTimeout());
 
             if (this.getMethod().equals("PUT") || this.getMethod().equals("POST")) {
                 request.setDoOutput(true);

--- a/src/com/akamai/netstorage/cli/CMS.java
+++ b/src/com/akamai/netstorage/cli/CMS.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
+import java.lang.Integer;
 
 import com.akamai.netstorage.DefaultCredential;
 import com.akamai.netstorage.NetStorage;
@@ -51,6 +52,8 @@ public class CMS {
         String outputfile = null;
         String targetFilename = null;
         String dstFilename = null;
+        int connectTimeout = 10000;
+        int readTimeout = 10000;
         boolean indexZip = false;
 
 
@@ -82,6 +85,11 @@ public class CMS {
                     case "-d":
                         dstFilename = arg;
                         break;
+                    case "-c":
+                        connectTimeout = Integer.parseInt(arg);
+                    case "-r":
+                        readTimeout = Integer.parseInt(arg);
+                        break;
                 }
                 firstarg = null;
             } else if (arg.equals("-indexzip"))
@@ -90,11 +98,12 @@ public class CMS {
                 netstorageURI = arg;
             else
                 firstarg = arg;
-        execute(action, user, key, netstorageURI, uploadfile, outputfile, targetFilename, dstFilename, indexZip);
+        execute(action, user, key, netstorageURI, uploadfile, outputfile, targetFilename, dstFilename, indexZip, connectTimeout,readTimeout);
     }
 
     public static void execute(String action, String user, String key, String netstorageURI,
-                        String uploadfile, String outputfile, String target, String dst, boolean indexZip) throws NetStorageException, IOException {
+                        String uploadfile, String outputfile, String target, String dst, boolean indexZip,
+                        int connectTimeout, int readTimeout) throws NetStorageException, IOException {
 
         String host = null;
         String path = netstorageURI;
@@ -118,7 +127,7 @@ public class CMS {
             host = hostpath[0];
             path = "/" + hostpath[1];
         }
-        NetStorage ns = new NetStorage(new DefaultCredential(host, user, key));
+        NetStorage ns = new NetStorage(new DefaultCredential(host, user, key), connectTimeout, readTimeout);
         InputStream result = null;
         boolean success = true;
 
@@ -211,6 +220,7 @@ public class CMS {
                 + "Usage: cms <-a action> <-u user> <-k key>\n"
                 + "[-o outfile] [-f srcfile]\n"
                 + "[-t targetpath] [-d newpath]\n"
+                + "[-c connectTimeout] [-r readTimeout]\n"
                 + "<-indexzip> <host/path>\n"
                 + "\n"
                 + "Where:\n"
@@ -219,6 +229,8 @@ public class CMS {
                 + "key             unique key used to sign api requests\n"
                 + "outfile         local file name to write when action=download\n"
                 + "srcfile         local file used as source when action=upload\n"
+                + "connectTimeout  http connect timeout in milliseconds\n"
+                + "readTimeout     http read timeout in milliseconds - useful when uploading via proxy\n"
                 + "targetpath      the absolute path (/1234/example.jpg) pointing to the existing target when action=symlink\n"
                 + "newpath         the absolute path (/1234/example.jpg) for the new file when action=rename\n"
                 + "host/path       the netstorage hostname and path to the file being manipulated (example.akamaihd.net/1234/example.jpg)\n"

--- a/src/com/akamai/netstorage/cli/CMS.java
+++ b/src/com/akamai/netstorage/cli/CMS.java
@@ -98,7 +98,13 @@ public class CMS {
                 netstorageURI = arg;
             else
                 firstarg = arg;
-        execute(action, user, key, netstorageURI, uploadfile, outputfile, targetFilename, dstFilename, indexZip, connectTimeout,readTimeout);
+
+        try {
+            execute(action, user, key, netstorageURI, uploadfile, outputfile, targetFilename, dstFilename, indexZip, connectTimeout,readTimeout);
+        } catch (NetStorageException e) {
+            System.out.println(e.getMessage());
+            throw e;
+        }
     }
 
     public static void execute(String action, String user, String key, String netstorageURI,

--- a/test/com/akamai/netstorage/NetStorageCMSv35SignerTest.java
+++ b/test/com/akamai/netstorage/NetStorageCMSv35SignerTest.java
@@ -155,13 +155,24 @@ public class NetStorageCMSv35SignerTest {
     }
 
     @Test
-    public void testValidateServerDateOutOfSync() throws Exception {
+    public void testValidateServerDateOutOfSyncPast() throws Exception {
         exception.expect(NetStorageException.class);
         exception.expectMessage("Local server Date is more than 30s out of sync with Remote server");
         NetStorageCMSv35Signer netStorageCMSv35Signer = createAPIConnection();
         HttpURLConnectionTest httpURLConnection = new HttpURLConnectionTest(netStorageCMSv35Signer.getUrl());
         httpURLConnection.setResponseCode(HttpURLConnection.HTTP_UNAVAILABLE);
         httpURLConnection.getHeaderFields().put("Date", Collections.singletonList("Mon, 11 Nov 1918 11:00:00 GMT"));
+        assertTrue(netStorageCMSv35Signer.validate(httpURLConnection));
+    }
+
+    @Test
+    public void testValidateServerDateOutOfSyncFuture() throws Exception {
+        exception.expect(NetStorageException.class);
+        exception.expectMessage("Local server Date is more than 30s out of sync with Remote server");
+        NetStorageCMSv35Signer netStorageCMSv35Signer = createAPIConnection();
+        HttpURLConnectionTest httpURLConnection = new HttpURLConnectionTest(netStorageCMSv35Signer.getUrl());
+        httpURLConnection.setResponseCode(HttpURLConnection.HTTP_UNAVAILABLE);
+        httpURLConnection.getHeaderFields().put("Date", Collections.singletonList("Wed, 1 Jan 3000 11:00:00 GMT"));
         assertTrue(netStorageCMSv35Signer.validate(httpURLConnection));
     }
 

--- a/test/com/akamai/netstorage/NetStorageTest.java
+++ b/test/com/akamai/netstorage/NetStorageTest.java
@@ -46,7 +46,10 @@ public class NetStorageTest {
 
         URLStreamHandlerFactoryTest.init();
 
-        NetStorage ns = new NetStorage(new DefaultCredential("www.example.com", "user1", "secret1"));
+        NetStorage ns = new NetStorage(new DefaultCredential("www.example.com", "user1", "secret1"), 20000, 20000);
+
+        assertEquals(ns.getConnectTimeout(), 20000);
+        assertEquals(ns.getReadTimeout(), 20000);
 
         HttpURLConnectionTest connection = URLStreamHandlerFactoryTest.addURLConnection(ns.getNetstorageUri(path));
         connection.setResponseCode(HttpURLConnection.HTTP_OK);


### PR DESCRIPTION
This is to assist when working with nonchunked requests via squid proxy where the hardcoded 10sec readTimeout is exceeded for large file uploads.  Also an error handling fix for date mismatches in future.